### PR TITLE
Update actions.js - add User argument to XSALVO command

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -293,6 +293,11 @@ module.exports = {
 				let salvo_args = []
 				let id_type = !isNaN(action.options.salvo_id) ? self.LRC_ARG_TYPE_NUMERIC : self.LRC_ARG_TYPE_STRING
 				salvo_args.push('ID' + id_type + '{' + action.options.salvo_id + '}')
+
+				// Suggested Correction for open issue 9
+				// Add User argument after ID when recalling a Salvo, as required on Platinum MX router
+				salvo_args.push(`U${self.LRC_ARG_TYPE_NUMERIC}{${self.config.user_id}}`)
+				
 				if (Object.prototype.hasOwnProperty.call(action.options, 'flags') && action.options.flags.length > 0) {
 					// F${FLAG,FLAG,FLAG}
 					salvo_args.push(`F${self.LRC_ARG_TYPE_STRING}{${action.options.flags.join()}}`)


### PR DESCRIPTION
Intended to address open issue #9.  Per Imagine Logical Router Control Operation and Reference Manual v 1.8, when using the :(change request) form of the XSALVO command (i.e. recall a Salvo), the User argument is required.  In my testing with a Platinum MX router the XSALVO command only works properly when the User argument is included, and fails otherwise. 

I am a very beginner coder and this code was generated with ChatGPT, it looks accurate to me but please look it over for any problems.  Thank you. 