### PR TITLE
Edits to actions.js and utils.js to address open Issues 9 and 10.

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -293,6 +293,13 @@ module.exports = {
 				let salvo_args = []
 				let id_type = !isNaN(action.options.salvo_id) ? self.LRC_ARG_TYPE_NUMERIC : self.LRC_ARG_TYPE_STRING
 				salvo_args.push('ID' + id_type + '{' + action.options.salvo_id + '}')
+
+				//Suggested correction for open issue 9
+				//Add user argument after ID when recalling a Salvo, as required on Platinum MX Router
+				//User argument is specified as required for this operation in LRC protocol
+				salvo_args.push(`U${self.LRC_ARG_TYPE_NUMERIC}{${self.config.user_id}}`)
+				//End correction
+
 				if (Object.prototype.hasOwnProperty.call(action.options, 'flags') && action.options.flags.length > 0) {
 					// F${FLAG,FLAG,FLAG}
 					salvo_args.push(`F${self.LRC_ARG_TYPE_STRING}{${action.options.flags.join()}}`)

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,7 +179,15 @@ module.exports = {
 			self.checkFeedbacks('salvo_state')
 		}
 
-		const salvo_state_match = responseData.matchAll(/~XSALVO!ID\${([^~\\{},]+)};V\${(ON|OFF)}\\/g)
+		//PREEXISTING CODE:
+		//const salvo_state_match = responseData.matchAll(/~XSALVO!ID\${([^~\\{},]+)};V\${(ON|OFF)}\\/g)
+		//
+		//Suggested correction for open issue 10
+		//Line below modified to also handle salvo numbers indicated by # and not just names indicated by $ .
+		//This code mirrors the above salvo_name_match command
+		const salvo_state_match = responseData.matchAll(/~XSALVO!ID[$#]{([^~\\{},]+)};V\${(ON|OFF)}\\/g)
+		//End
+
 		const salvo_state_matches = [...salvo_state_match]
 		if (salvo_state_matches.length > 0) {
 			// Update Salvo State (for feedback)


### PR DESCRIPTION
Made corrections in actions.js and utils.js to address open issues 9 and 10.  I have tested these changes locally with my Platinum MX router and they solve the identified issues without causing errors.  I am a novice coder and made these changes with the assistance of Copilot and ChatGPT to get the syntax correct; it tests fine and looks accurate to me but please look it over for any problems.  

*** Change to actions.js ***
Per Imagine Communcations LRC Operation and Reference manual v 1.8 - when using the :(change request) form of the XSALVO command (i.e. recall a Salvo), the User argument is required. In my testing with a Platinum MX router the XSALVO command only works properly when the User argument is included, and fails otherwise.  This change adds the User argument after the ID argument when recalling a Salvo.

***Change to utils.js ***

When using a Platinum MX router, Companion updates the Salvo states properly when initially querying router, when it sends XSALVO%ID#{4} - but it does not update salvo state when the router sends an update of the type XSALVO!ID#{4} .  (Notice the % vs the !)  

The original code at line 182 that processes Salvo updates is looking for a salvo name of the type ID${Name} but not responding to a salvo number of the type ID#{Number} .  My router is sending Salvo updates with a number, not a name.  This change is intended to capture both options. 






