### PR TITLE
Improve user input parsing for XPOINT state feedback

### DIFF
--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -66,11 +66,13 @@ module.exports = {
 				},
 			],
 			callback: async (feedback, context) => {
-				let xpoint_dest_id = feedback.options.dest
-				const parsed_dest_id = await context.parseVariablesInString(xpoint_dest_id)
+				const parsed_dest_id = await context.parseVariablesInString(feedback.options['dest'])
+				const parsed_src_id = await context.parseVariablesInString(feedback.options['source'])
 				let xpoint_dest_target = self.findTarget('destination', parsed_dest_id)
-				if (xpoint_dest_target && Object.prototype.hasOwnProperty.call(xpoint_dest_target, 'source')) {
-					return xpoint_dest_target.source === feedback.options.source
+				let xpoint_src_target = self.findTarget('source', parsed_src_id);
+				if (!xpoint_dest_target || !xpoint_src_target) { return false; }
+				if (Object.prototype.hasOwnProperty.call(xpoint_dest_target, 'source')) {
+					return xpoint_dest_target.source === xpoint_src_target.id || xpoint_dest_target.source === xpoint_src_target.label;
 				} else {
 					self.log('warn', `Destination '${parsed_dest_id}' not found or no state property`)
 					return false


### PR DESCRIPTION
**Improve feedback method for crosspoint state, to allow name/numeric parsing on both sources & destination inputs.**

In the existing version, the callback only parses the `destination` entry into a matching destination object from it's knowledge of the routing database. This makes it difficult to input a name or number that matches what the callback is trying to match. By parsing and selecting a matching source and destination entry for both user inputs, we can assure that no matter what method we're using for specifying parameters that we're interpreting the routing state properly. 