### PR TITLE
Salvo Improvements

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -53,6 +53,9 @@ Request execution of a crosspoint salvo.
 One salvo can be specified in each action.
 Optionally, one or more flags may be specified to adjust behavior of the request.
 
+Some implementations of LRC (e.g. on a Imagine Platinum MX as reported in #9) seem to require inclusion of a user ID to properly execute XSALVO commands.
+If you are attempting to use XSALVO commands and they're not working, you may need to enable the `Send User ID with XSALVO Commands` configuration option.
+
 ### Destination Lock (LOCK)
 
 Secure a destination from further crosspoint status changes by any User ID including the lock owner.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447",
 	"dependencies": {
-		"@companion-module/base": "~1.8.0"
+		"@companion-module/base": "~1.11.0"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "^1.5.1"

--- a/src/actions.js
+++ b/src/actions.js
@@ -292,7 +292,10 @@ module.exports = {
 				let lrc_op = self.LRC_OP_CHANGE_REQUEST.id
 				let salvo_args = []
 				let id_type = !isNaN(action.options.salvo_id) ? self.LRC_ARG_TYPE_NUMERIC : self.LRC_ARG_TYPE_STRING
-				salvo_args.push('ID' + id_type + '{' + action.options.salvo_id + '}')
+				salvo_args.push(`ID${id_type}{${action.options.salvo_id}}`)
+				if (self.config.send_user_id_with_xsalvo === true) {
+					salvo_args.push(`U${self.LRC_ARG_TYPE_NUMERIC}{${self.config.user_id}}`)
+				}
 				if (Object.prototype.hasOwnProperty.call(action.options, 'flags') && action.options.flags.length > 0) {
 					// F${FLAG,FLAG,FLAG}
 					salvo_args.push(`F${self.LRC_ARG_TYPE_STRING}{${action.options.flags.join()}}`)

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,7 @@ module.exports = {
 				max: 65535,
 				default: 0,
 				required: true,
-				tooltip: 'Numeric identifier for any commands requiring this parameter (e.g. LOCK, PROTECT, XBUFFER)',
+				tooltip: 'Numeric identifier for any commands requiring this parameter (e.g. LOCK, PROTECT, XBUFFER, XSALVO)',
 			},
 			{
 				type: 'number',
@@ -63,6 +63,16 @@ module.exports = {
 					'Sets sources/destinations used in crosspoint commands to be sent as either numbers (default)' +
 					' or names. If you use a variable in the respective fields, you should set this to the same format' +
 					' as your variable values as the values will be sent unmodified.',
+			},
+			{
+				type: 'checkbox',
+				id: 'send_user_id_with_xsalvo',
+				label: 'Send User ID with XSALVO Commands',
+				width: 6,
+				default: false,
+				tooltip: 'Some implementations of LRC require including a user ID with XSALVO commands. ' +
+									'Other implementations break entirely if the value is included. If you find that ' +
+									'your XSALVO commands are not working, you may need to enable this.'
 			},
 		]
 	},

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,7 +179,7 @@ module.exports = {
 			self.checkFeedbacks('salvo_state')
 		}
 
-		const salvo_state_match = responseData.matchAll(/~XSALVO!ID\${([^~\\{},]+)};V\${(ON|OFF)}\\/g)
+		const salvo_state_match = responseData.matchAll(/~XSALVO!ID[$#]{([^~\\{},]+)};V\${(ON|OFF)}\\/g)
 		const salvo_state_matches = [...salvo_state_match]
 		if (salvo_state_matches.length > 0) {
 			// Update Salvo State (for feedback)


### PR DESCRIPTION
- Bump Companion module base
- Add the option to include the User ID in XSALVO commands for implementations of LRC that need it (defaults to off/disabled) (Fixes #9)
- Salvo state should match on both numeric and string identifiers (Fixes #10)